### PR TITLE
no extra margin paddings when app's running on a mobile device

### DIFF
--- a/inst/shiny-examples/ShinyItemAnalysis/ui.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/ui.R
@@ -19,7 +19,10 @@ ui = tagList(
                        "body {padding-top: 110px; padding-left: 80px; padding-right: 80px; }"),
             tags$link(rel = "stylesheet",
                       type = "text/css",
-                      href = "flag-icon.css")
+                      href = "flag-icon.css"),
+			tags$link(rel = "stylesheet",
+                      type = "text/css",
+                      href = "mobile_device_paddings.css")
             ),
 
   div(class = "busy",

--- a/inst/shiny-examples/ShinyItemAnalysis/ui.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/ui.R
@@ -20,7 +20,7 @@ ui = tagList(
             tags$link(rel = "stylesheet",
                       type = "text/css",
                       href = "flag-icon.css"),
-			tags$link(rel = "stylesheet",
+            tags$link(rel = "stylesheet",
                       type = "text/css",
                       href = "mobile_device_paddings.css")
             ),

--- a/inst/shiny-examples/ShinyItemAnalysis/www/mobile_device_paddings.css
+++ b/inst/shiny-examples/ShinyItemAnalysis/www/mobile_device_paddings.css
@@ -1,0 +1,16 @@
+@media (max-width: 978px) {
+    .container {
+      padding:0;
+      margin:0;
+    }
+
+    body {
+      padding:0;
+    }
+
+    .navbar-fixed-top, .navbar-fixed-bottom, .navbar-static-top {
+      margin-left:0;
+      margin-right:0;
+      margin-bottom:0;
+    }
+}


### PR DESCRIPTION
I added .css class handling margin (left and right) paddings width when the
application is running on a mobile device. It means there are no extra
margin paddings (i. e. plots are sufficiently large) whenever the device
screen width is lower than 978 px (sometimes is recommended to set the
screen width cut-off at 480 px).
