### PR TITLE
item response patterns plot and custom discrimination plot added

### DIFF
--- a/inst/shiny-examples/ShinyItemAnalysis/server.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/server.R
@@ -848,6 +848,8 @@ function(input, output, session) {
   #%%%%%%%%%%%%%%%%%%%%%%%%%%%
   # TRADITIONAL ANALYSIS #####
   #%%%%%%%%%%%%%%%%%%%%%%%%%%%
+  
+
 
   # * ITEM ANALYSIS #####
   # ** Difficulty/Discrimination plot ######
@@ -1096,7 +1098,271 @@ function(input, output, session) {
   output$distractor_table_proportions_Input <- renderTable({
     distractor_table_proportions_Input()
   })
-
+  
+  ## "item response patterns distribution plot" -------------------------------------
+  item_response_patterns_distribution_plot_Input_f <- function(){
+    
+    my_data <- setNames(          
+      distractor_table_counts_Input()[, "Total"],
+      as.character(distractor_table_counts_Input()[, "Response"])
+    )
+    
+    my_data <- my_data[names(my_data) != "Total"]
+    
+    if(
+      input$type_combinations_distractor != "Combinations"
+    ){
+      my_data <- my_data[nchar(gsub("X", "", names(my_data))) == 1]
+    }
+    
+    par(mar = c(4.1, 4.1, 2.1, 0.1), xpd = TRUE)
+    
+    barplot(
+      my_data / sum(my_data),
+      col = "lightgrey",
+      ylim = c(0.0, 1.0),
+      xlab = "Item Response Pattern",
+      ylab = "Item Response Pattern Relative Frequency",
+      cex.lab = 1.2
+    )
+    
+    box()
+    
+    mtext(
+      text = paste("Item ", item_numbers()[input$distractorSlider], sep = ""),
+      side = 3,
+      line = 1,
+      adj = 0,
+      font = 2,
+      cex = 1.3
+    )
+    
+  }
+  
+  item_response_patterns_distribution_plot_Input <- reactive({
+    item_response_patterns_distribution_plot_Input_f()
+  })
+  
+  
+  ## rendering of "item response patterns distribution plot" ------------------------
+  output$item_response_patterns_distribution_plot <- renderPlot({
+      
+    item_response_patterns_distribution_plot_Input()
+      
+  })
+  
+  
+  ## "item response patterns distribution plot" downloading handler -----------------
+  
+  output$item_response_patterns_distribution_plot_download <- downloadHandler(
+    
+    filename =  function() {
+      paste(
+        "item_response_patterns_distribution_plot_item_",
+        item_numbers()[input$distractorSlider],
+        ".png",
+        sep = ""
+      )
+    },
+    
+    content = function(file) {
+      
+      png(
+        filename = file,
+        height = 5,
+        width = if(input$type_combinations_distractor == "Combinations"){12}else{6},
+        units = "in",
+        res = 600
+      )
+      
+      item_response_patterns_distribution_plot_Input_f()
+      
+      dev.off()
+      
+    }
+    
+  )
+  
+  
+  ## double slider for min and max index of group ---------------------------------
+  
+  output$distractor_double_slider <- renderUI({
+    
+    sliderInput(
+      "range",
+      "Which two groups to compare:",
+      min = 1,
+      max = input$gr,
+      step = 1,
+      value = c(1, min(3, input$gr))
+    )
+    
+  })
+  
+  
+  ## "item response patterns distribution plot" -------------------------------------
+  custom_DD_plot_Input_f <- function(){
+    
+    item_distractor_table_counts <- function(my_item_index){
+      a <- test_answers()
+      k <- test_key()
+      num.group <- input$gr
+      item <- my_item_index
+      
+      DA <- DistractorAnalysis(a, k, num.groups = num.group)[[item]]
+      df <- dcast(as.data.frame(DA), response ~ score.level, sum, margins = T, value.var = "Freq")
+      colnames(df) <- c("Response", paste("Group", 1:num.group), "Total")
+      levels(df$Response)[nrow(df)] <- "Total"
+      df
+    }
+    
+    my_parameters <- lapply(
+      1:length(test_key()),
+      function(i){
+        my_table <- item_distractor_table_counts(i)
+        
+        my_difficulty_proportions <- my_table[
+          my_table[, "Response"] == as.character(test_key())[i], "Total"
+          ] / my_table[
+            my_table[, "Response"] == "Total", "Total"
+            ]
+        
+        my_discrimination_proportions <- my_table[
+          my_table[, "Response"] == as.character(test_key())[i], -c(1, dim(my_table)[2])
+          ] / my_table[
+            my_table[, "Response"] == "Total", -c(1, dim(my_table)[2])
+            ]
+        
+        return(c(
+          unlist((my_difficulty_proportions)),
+          unlist((my_discrimination_proportions[
+            as.integer(input$range[[2]])
+            ] - my_discrimination_proportions[
+              as.integer(input$range[[1]])
+              ]))
+        ))
+      }
+    )
+    
+    my_parameters <- setNames(
+      my_parameters,
+      1:length(test_key())
+    )
+    
+    barplot(
+      rbind(
+        unlist(lapply(my_parameters, "[[", 1))[order(unlist(lapply(my_parameters, "[[", 1)))],
+        unlist(lapply(my_parameters, "[[", 2))[order(unlist(lapply(my_parameters, "[[", 1)))]
+      ),
+      beside = TRUE,
+      space = c(0.0, 1.0),
+      col = c("red", "blue"),
+      xlab = "Item numbers",
+      ylim = c(0, 1),
+      horiz = FALSE,
+      xaxt = "n",
+      cex.lab = 1.2
+    )
+    
+    axis(
+      1,
+      at = seq(2, 2 + 3 * (length(my_parameters) - 1), by = 3),
+      labels = 1:length(test_key()), cex.lab = 1.2
+    )
+    
+    legend(
+      x = "topleft",
+      legend = c(
+        "difficulty",
+        "discrimination"
+      ),
+      pch = 19,
+      col = c("red", "blue"),
+      bg = "white",
+      title = expression(bold("legend")),
+      bty = "n"
+      
+    )
+    
+    
+  }
+  
+  ## "item response patterns distribution plot" reactive -------------------------------
+  custom_DD_plot_Input <- reactive({
+    
+    if(is.null(test_answers())){return(NULL)}
+    if(is.null(test_key())){return(NULL)}
+    if(is.null(input$gr)){return(NULL)}
+    if(is.null(input$range)){return(NULL)}
+    
+    
+    custom_DD_plot_Input_f()
+    
+  })
+  
+  
+  ## "item response patterns distribution plot"  rendering ------------------------------
+  output$custom_DD_plot <- renderPlot({
+    
+    if(is.null(test_answers())){return(NULL)}
+    if(is.null(test_key())){return(NULL)}
+    if(is.null(input$gr)){return(NULL)}
+    if(is.null(input$range)){return(NULL)}
+    if(is.null(custom_DD_plot_Input())){return(NULL)}
+    
+    custom_DD_plot_Input()
+    
+  })
+  
+  
+  ## "item response patterns distribution plot" download handler ------------------------
+  output$custom_DD_plot_download <- downloadHandler(
+    
+    filename =  function() {
+      "custom_DD_plot_item.png"
+    },
+    
+    content = function(file) {
+      
+      png(
+        filename = file,
+        height = 5,
+        width = length(test_key()) * 0.5,
+        units = "in",
+        res = 600
+      )
+      
+      custom_DD_plot_Input_f()
+      
+      dev.off()
+      
+    }
+    
+  )
+  
+  output$custom_DD_plot_text <- renderUI({
+    
+    if(is.null(test_answers())){return(NULL)}
+    if(is.null(test_key())){return(NULL)}
+    if(is.null(input$gr)){return(NULL)}
+    if(is.null(input$range)){return(NULL)}
+    if(is.null(custom_DD_plot_Input())){return(NULL)}
+    
+    HTML(paste(
+      "Discrimination is here a difference between the difficulty recorded in the ",
+      "<b>", input$range[[2]], "</b>",
+      if(input$range[[2]] == 1){"-st"}else{if(input$range[[2]] == 2){"-nd"}else{if(input$range[[2]] == 3){"-rd"}else{"-th"}}},
+      " and the ",
+      "<b>", input$range[[1]], "</b>",
+      if(input$range[[1]] == 1){"-st"}else{if(input$range[[1]] == 2){"-nd"}else{if(input$range[[1]] == 3){"-rd"}else{"-th"}}},
+      " group.",
+      sep = ""
+    ))
+    
+  })
+  
+  
+  
   #%%%%%%%%%%%%%%%%%%%%%%%%%%%
   # REGRESSION ###############
   #%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/inst/shiny-examples/ShinyItemAnalysis/ui.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/ui.R
@@ -760,6 +760,11 @@ ui = tagList(
                                  br(),
                                  h4("Table with counts"),
                                  fluidRow(column(12, align = "center", tableOutput('distractor_table_counts'))),
+                                 plotOutput("item_response_patterns_distribution_plot"),
+                                 downloadButton(
+                                   "item_response_patterns_distribution_plot_download",
+                                   label = "Download figure"
+                                 ),
                                  h4("Table with proportions"),
                                  fluidRow(column(12, align = "center", tableOutput('distractor_table_proportions'))),
                                  br(),
@@ -769,6 +774,15 @@ ui = tagList(
                                  br(),
                                  h4('Table of total scores by groups'),
                                  fluidRow(column(12, align = "center", tableOutput('distractor_table_group'))),
+                                 br(),
+                                 h4("Diagram of custom discrimination"),
+                                 uiOutput("distractor_double_slider"),
+                                 htmlOutput("custom_DD_plot_text"),
+                                 plotOutput("custom_DD_plot"),
+                                 downloadButton(
+                                   "custom_DD_plot_download",
+                                   label = "Download figure"
+                                 ),
                                  br(),
                                  h4("Selected R code"),
                                  div(code('library(difNLR)'),


### PR DESCRIPTION
I added functions, reactives and download handlers for item response patterns plot and custom discrimination plot (two of "FedCSIS" plots). The second one seems to be computed a little bit slowly for large datasets (Medical 100) -- what is more, it is quite similar to classical difficulty-discrimination plot, however, a user can set her own discrimination "ULI" dynamically in this version of the plot.
