### PR TITLE
change of report downloading logic

### DIFF
--- a/inst/shiny-examples/ShinyItemAnalysis/server.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/server.R
@@ -4618,7 +4618,18 @@ function(input, output, session) {
          incProgress(0.3)
     )
     })
+    
+    output$download_report_button <- renderUI({
+      
+      if(is.null(input$generate)){return(NULL)}
+      downloadButton("report", "Download report")
+      
+    })
+    
   })
+  
+
+  
 
   output$report <- downloadHandler(
     filename = reactive({paste0("report.", input$report_format)}),

--- a/inst/shiny-examples/ShinyItemAnalysis/ui.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/ui.R
@@ -2962,8 +2962,14 @@ ui = tagList(
                            sections of intended contents. For example, if you wish to include a ", strong("3PL IRT"),
                            " model, you can first visit ", strong("IRT models"), "section and ", strong("3PL"), " subsection."),
                          #p(strong("Warning: "), "Download of reports takes some time. Please, be patient."),
-                         actionButton("generate", "Generate report"),
-                         downloadButton("report", "Download report"),
+                         fluidRow(
+                           column(width = 3,
+                             splitLayout(
+                               actionButton("generate", "Generate report"),
+                               uiOutput("download_report_button")
+                             )
+                           )
+                         ),
                          br(),
                          br(),
                          br()

--- a/inst/shiny-examples/ShinyItemAnalysis/www/busy.js
+++ b/inst/shiny-examples/ShinyItemAnalysis/www/busy.js
@@ -12,9 +12,9 @@ setInterval(function(){
 
 $(function() {
 
-    $('#generate').click(function() {
+    $('#report').click(function() {
         alert(
-          'Generating of reports takes some time. Please, be patient. Please do not change the settings of application before the download is completed. A download button will occure when the report is ready. \n \n (Press "OK" to start report generating.)'
+          'Downloading of reports takes some time. Please, be patient. Please do not change the settings of application before the download is completed. \n \n (Press "OK" to start report generating.)'
         );
         /*setInterval();*/
     });

--- a/inst/shiny-examples/ShinyItemAnalysis/www/busy.js
+++ b/inst/shiny-examples/ShinyItemAnalysis/www/busy.js
@@ -12,9 +12,9 @@ setInterval(function(){
 
 $(function() {
 
-    $('#report').click(function() {
+    $('#generate').click(function() {
         alert(
-          'Downloading of reports takes some time. Please, be patient. Please do not change the settings of application before the download is completed. \n \n (Press "OK" to start report generating.)'
+          'Generating of reports takes some time. Please, be patient. Please do not change the settings of application before the download is completed. A download button will occure when the report is ready. \n \n (Press "OK" to start report generating.)'
         );
         /*setInterval();*/
     });


### PR DESCRIPTION
If you will agree, I'd suggest a change of logic of the report
downloading: firstly, a user clicks on generate button (so far so good),
but, the download button is not available at this moment. When the user starts generating the report, message box with some time consumption warnings will pop up (as expected), then the process of report generating will follow, while progress bar is displayed (as expected as
well).  The download button is still not available up to now and is dynamically rendered just at the moment the report is prepared.
