### PR TITLE
Minor changes -- opacity of the footer for text-areas like "No file selected"

### DIFF
--- a/inst/shiny-examples/ShinyItemAnalysis/ui.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/ui.R
@@ -88,7 +88,7 @@ ui = tagList(
              selected = 'About',
              collapsible = TRUE,
              footer = list(
-               HTML('<div class = "panel-footer">
+               HTML('<div class = "panel-footer", style = "opacity: 1.00; z-index: 1000;">
                     <p style = "margin:8px 0 0 0;">
                     <div class = "footer-title">
                     <img src = "hexbin.png">


### PR DESCRIPTION
The footer of the application is transparent to placeholders of text-areas such as "No file selected" placed on the second tab "Data", i. e. the placeholders like "No file selected" are displayed in front of the footer when scrolled at the same level. I suppose this is undesirable, therefore I have increased an opacity of the footer to its maximum just to avoid the accidental appearance of the text-areas in front of the footer.
