### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/R/ItemAnalysis.R
+++ b/R/ItemAnalysis.R
@@ -82,7 +82,7 @@
 #' Martinkova, P., Stepanek, L., Drabinova, A., Houdek, J., Vejrazka, M., & Stuka, C. (2017).
 #' Semi-real-time analyses of item characteristics for medical school admission tests.
 #' In: Proceedings of the 2017 Federated Conference on Computer Science and Information Systems.
-#' http://dx.doi.org/10.15439/2017F380
+#' https://doi.org/10.15439/2017F380
 #'
 #' Allen, M. J. & Yen, W. M. (1979). Introduction to measurement theory. Monterey, CA: Brooks/Cole.
 #'

--- a/R/gDisrim.R
+++ b/R/gDisrim.R
@@ -50,7 +50,7 @@
 #' Martinkova, P., Stepanek, L., Drabinova, A., Houdek, J., Vejrazka, M., & Stuka, C. (2017).
 #' Semi-real-time analyses of item characteristics for medical school admission tests.
 #' In: Proceedings of the 2017 Federated Conference on Computer Science and Information Systems.
-#' http://dx.doi.org/10.15439/2017F380
+#' https://doi.org/10.15439/2017F380
 #'
 #' @note
 #' \code{gDiscrim} is used by \code{\link{DDplot}} function.

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ If you find any bug or just need help with `ShinyItemAnalysis` you can leave you
 This program is free software and you can redistribute it and or modify it under the terms of the [GNU GPL 3](https://www.gnu.org/licenses/gpl-3.0.en.html).
 
 ## References
-New paper is available in [The R Journal](https://journal.r-project.org/archive/2018/RJ-2018-074/). Czech speakers can also refer to paper in journal [Testforum](http://dx.doi.org/10.5817/TF2017-9-129).
+New paper is available in [The R Journal](https://journal.r-project.org/archive/2018/RJ-2018-074/). Czech speakers can also refer to paper in journal [Testforum](https://doi.org/10.5817/TF2017-9-129).

--- a/inst/shiny-examples/ShinyItemAnalysis/ui/uiAbout.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/ui/uiAbout.R
@@ -145,7 +145,7 @@ uiAbout <- tabPanel("",
                     ShinyItemAnalysis: Analyza prijimacich a jinych znalostnich ci psychologickych testu. [ShinyItemAnalysis: Analyzing admission and other educational and psychological tests. In Czech].", br(), "
                     TESTFORUM, 6(9), 16-35. doi:",
 				            a("10.5817/TF2017-9-129",
-				              href = "http://dx.doi.org/10.5817/TF2017-9-129",
+				              href = "https://doi.org/10.5817/TF2017-9-129",
 				              target = "_blank")),
 
                   tags$hr(),

--- a/inst/shiny-examples/ShinyItemAnalysis/ui/uiReferences.R
+++ b/inst/shiny-examples/ShinyItemAnalysis/ui/uiReferences.R
@@ -367,7 +367,7 @@ uiReferences <-
                 In
                 <i>Proceedings of the 2017 Federated Conference on Computer Science and Information Systems</i>,
                 189-194.
-                <a href="http://dx.doi.org/10.15439/2017F380",
+                <a href="https://doi.org/10.15439/2017F380",
                 target="_blank">See online.</a>
                 </li>
                 

--- a/man/ItemAnalysis.Rd
+++ b/man/ItemAnalysis.Rd
@@ -105,7 +105,7 @@ maxscore = 4, minscore = 0, cutscore = 4, add.bin = TRUE) )
 Martinkova, P., Stepanek, L., Drabinova, A., Houdek, J., Vejrazka, M., & Stuka, C. (2017).
 Semi-real-time analyses of item characteristics for medical school admission tests.
 In: Proceedings of the 2017 Federated Conference on Computer Science and Information Systems.
-http://dx.doi.org/10.15439/2017F380
+https://doi.org/10.15439/2017F380
 
 Allen, M. J. & Yen, W. M. (1979). Introduction to measurement theory. Monterey, CA: Brooks/Cole.
 }

--- a/man/gDiscrim.Rd
+++ b/man/gDiscrim.Rd
@@ -68,7 +68,7 @@ gDiscrim(dataOrd,  k = 5, l = 4, u = 5, maxscore = 4, minscore = 0)[1:5]
 Martinkova, P., Stepanek, L., Drabinova, A., Houdek, J., Vejrazka, M., & Stuka, C. (2017).
 Semi-real-time analyses of item characteristics for medical school admission tests.
 In: Proceedings of the 2017 Federated Conference on Computer Science and Information Systems.
-http://dx.doi.org/10.15439/2017F380
+https://doi.org/10.15439/2017F380
 }
 \seealso{
 \code{\link{DDplot}}


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update all static DOI links accordingly.

Cheers!